### PR TITLE
enable new staking contracts

### DIFF
--- a/bclient/bclient.go
+++ b/bclient/bclient.go
@@ -93,6 +93,10 @@ func (c *Client) StakingAt(contractType string) (*stakingbindings.Stakingbinding
 		return stakingbindings.NewStakingbindings(DEFI5StakingAddress, c.ec)
 	case "univ2-eth-defi5":
 		return stakingbindings.NewStakingbindings(DEFI5UNILPStakingAddress, c.ec)
+	case "cc10":
+		return stakingbindings.NewStakingbindings(CC10StakingAddress, c.ec)
+	case "univ2-eth-cc10":
+		return stakingbindings.NewStakingbindings(CC10UNILPStakingAddress, c.ec)
 	default:
 		return nil, errors.New("unsupported staking contract")
 	}

--- a/bclient/bclient_test.go
+++ b/bclient/bclient_test.go
@@ -39,8 +39,27 @@ func TestBClient(t *testing.T) {
 		require.Equal(t, "MKR", guessTokenSymbol("0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"))
 	})
 	t.Run("CC10", func(t *testing.T) {
-		_, err := client.CC10()
+		cc10, err := client.CC10()
 		require.NoError(t, err)
+		t.Run("CC10_MCAP_Controller", func(t *testing.T) {
+			_, err := client.MCAPControllerAt(cc10)
+			require.NoError(t, err)
+		})
+		t.Run("CC10_UNISWAP_ORACLE", func(t *testing.T) {
+			addr, err := client.OracleFor(cc10)
+			require.NoError(t, err)
+			t.Log("cc10 uniswap oracle address: ", addr)
+			orc, err := client.OracleAt(cc10)
+			require.NoError(t, err)
+			tokens, err := client.PoolTokensFor(cc10)
+			require.NoError(t, err)
+			for name, addr := range tokens {
+				// get time weighted average price of token in terms of weth
+				price, err := orc.ComputeAverageTokenPrice(nil, addr, big.NewInt(0), big.NewInt(36288000)) // price between 0 seconds and 7 days
+				require.NoError(t, err)
+				t.Logf("token %s (%s) average eth price %s", addr, name, price.X)
+			}
+		})
 	})
 	t.Run("DEFI5", func(t *testing.T) {
 		defi5, err := client.DEFI5()

--- a/bclient/types.go
+++ b/bclient/types.go
@@ -6,16 +6,24 @@ import (
 )
 
 var (
-	defi5Addr           = "0xfa6de2697d59e88ed7fc4dfe5a33dac43565ea41"
-	defi5StakeAddr      = "0x11bf850D1B85eA02eF9F06Cf09488E443655b586"
+	defi5Addr      = "0xfa6de2697d59e88ed7fc4dfe5a33dac43565ea41"
+	defi5StakeAddr = "0x11bf850D1B85eA02eF9F06Cf09488E443655b586"
+	// ETH-DEFI5 stake contract
 	defi5UNILPStakeAddr = "0x04834fE50BE6954088d979A84bE20913efCA9118"
-	cc10Addr            = "0x17ac188e09a7890a1844e5e65471fe8b0ccfadf3"
+	// ETH-CC10 stake contract
+	cc10UNILPStakeAddr = "0x08F0d214d6A80520F18E6837e2cc40899E67B5c0"
+	cc10Addr           = "0x17ac188e09a7890a1844e5e65471fe8b0ccfadf3"
+	cc10StakeAddr      = "0xE1dE5Ebd607f1Da1c34D78b760B9C87901d0Ba35"
 	// DEFI5TokenAddress is the address of the DEFI5 token/pool contract
 	DEFI5TokenAddress = common.HexToAddress(defi5Addr)
 	// DEFI5StakingAddress is the address of the DEFI5 staking contract
 	DEFI5StakingAddress = common.HexToAddress(defi5StakeAddr)
+	// CC10StakingAddress is the address of the CC10 staking contract
+	CC10StakingAddress = common.HexToAddress(cc10StakeAddr)
 	// DEFI5UNILPStakingAddress is the address of the ETH-DEFI5 Uniswap staking contract
 	DEFI5UNILPStakingAddress = common.HexToAddress(defi5UNILPStakeAddr)
+	// CC10UNILPStakingAddress is the address of the ETH-CC10 uniswap staking contract
+	CC10UNILPStakingAddress = common.HexToAddress(cc10UNILPStakeAddr)
 	// CC10TokenAddress is the address of the CC10 token/pool contract
 	CC10TokenAddress = common.HexToAddress(cc10Addr)
 	// WETHTokenAddress is the address of the WETH token contract

--- a/discord/discord.go
+++ b/discord/discord.go
@@ -141,7 +141,7 @@ func NewClient(ctx context.Context, cfg *Config, bc *bclient.Client, db *db.Data
 
 	router.RegisterCmd(&dgc.Command{
 		Name:        "stake-earned",
-		Description: "returns the amount of stake earned, currently supports defi5 and univ2-eth-defi5 stake contracts",
+		Description: "returns the amount of stake earned. <stake-type> can be one of: defi5, univ2-eth-defi5, cc10, univ2-eth-cc10",
 		Usage:       " stake-earned <stake-type> <account>",
 		Example:     " stake-earned defi5 0x5a361A1dfd52538A158e352d21B5b622360a7C13",
 		IgnoreCase:  true,


### PR DESCRIPTION
adds the contract addresses for the newly released CC10 staking contracts, and enables querying them through the discord bot.